### PR TITLE
2023 python version bump 

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12.0-alpha.1", "pypy-3.8"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12.0", "pypy-3.8"]
 
     steps:
     - uses: actions/checkout@v3

--- a/oops_all_itertools/__init__.py
+++ b/oops_all_itertools/__init__.py
@@ -4,4 +4,4 @@ from itertools import *  # noqa
 
 from more_itertools import *  # noqa
 
-__version__ = "2.0.2"
+__version__ = "3.0.0"

--- a/oops_all_itertools/__init__.py
+++ b/oops_all_itertools/__init__.py
@@ -4,4 +4,4 @@ from itertools import *  # noqa
 
 from more_itertools import *  # noqa
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,11 @@ classifiers = [
     "Natural Language :: English",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
@@ -35,7 +35,7 @@ classifiers = [
 ]
 dynamic = ["version", "description"]
 dependencies = [
-    "more-itertools == 9.1.0",
+    "more-itertools == 10.1.0",
 ]
 
 [project.urls]

--- a/tests/test_oops_all.py
+++ b/tests/test_oops_all.py
@@ -6,4 +6,4 @@ import oops_all_itertools as oai
 class DoesItImport(TestCase):
     def test_quantity(self):
         """Test that a specific pile of stuff was imported"""
-        self.assertEqual(len(dir(oai)), 167)
+        self.assertEqual(len(dir(oai)), 175)


### PR DESCRIPTION
* drop support for python 3.7
* add support for python 3.12

* bumps version of more-itertools

note: the latest version of more-itertools does not support 3.12 yet, but dev does. This is not suitable for publishing until a more-itertools update is produced